### PR TITLE
Fix build selector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@
 language: objective-c
 
 env:
-  env:
   matrix:
+    
     - CONDA_PY=27
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
@@ -31,7 +31,7 @@ install:
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-
+      
 
 script:
   - conda build ./recipe

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ About conda-forge
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the
-conda-forge GitHub organization. The conda-forge organization contains one repository
+conda-forge GitHub organization. The conda-forge organization contains one repository 
 for each of the installable packages. Such a repository is known as a *feedstock*.
 
 A feedstock is made up of a conda recipe (the instructions on what and how to build
@@ -71,7 +71,7 @@ Current build status
 ====================
 
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/m2crypto-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/m2crypto-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/m2crypto-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/m2crypto-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/m2crypto-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/m2crypto-feedstock) 
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/m2crypto-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/m2crypto-feedstock/branch/master)
 
 Current release info
@@ -92,7 +92,7 @@ install and use.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string).
+   the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string). 
  * If the version of a package **is** being increased, please remember to return
    the [``build/number``](http://conda.pydata.org/docs/building/meta-yaml.html#build-number-and-string)
    back to 0.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 1
-  skip: True  # [not win or py3k]
+  skip: True  # [win or py3k]
   preserve_egg_dir: yes
 
 requirements:


### PR DESCRIPTION
Closes https://github.com/conda-forge/m2crypto-feedstock/pull/5

Selector was skiping linux and OS X instead of windows.