### PR TITLE
m2crypto v0.31.0 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fd59a9705275d609948005f4cbcaf25f28a4271308237eb166169528692ce498
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
Somehow the Linux build failed after merging #24. Simply try to do it again?

(Or is it preferred to restart the failed Circle CI builds on the master branch commit? Not sure about the conda-forge workflow here..)

![screenshot from 2018-11-21 11 04 50](https://user-images.githubusercontent.com/1842780/48834142-4fc7f700-ed7d-11e8-8132-82f13fe89543.png)


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
