### PR TITLE
Patch out unnecessary test requirement

### DIFF
--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -22,3 +22,6 @@ python:
 - 3.6.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -22,3 +22,6 @@ python:
 - 3.7.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -22,3 +22,6 @@ python:
 - 3.8.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -22,3 +22,6 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,4 +1,0 @@
-"%PYTHON%" setup.py build build_ext --openssl="%LIBRARY_PREFIX%"
-if errorlevel 1 exit 1
-"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# Use PREFIX to use conda openssl
-$PYTHON setup.py build build_ext --openssl $PREFIX
-$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,9 @@ package:
 source:
   url: https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-{{ version }}.tar.gz
   sha256: e4e42f068b78ccbf113e5d0a72ae5f480f6c3ace4940b91e4fff5598cfff6fb3
+  patches:
+    # remove parameterized from install_requires, it's only used in the tests
+    - no-parameterized.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: e4e42f068b78ccbf113e5d0a72ae5f480f6c3ace4940b91e4fff5598cfff6fb3
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,10 @@ test:
   imports:
     - M2Crypto
     - M2Crypto.SSL
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://gitlab.com/m2crypto/m2crypto

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - {{ compiler("c") }}
   host:
     - openssl
+    - pip
     - python
     - setuptools
     - swig >=2.0.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "M2Crypto" %}
 {% set version = "0.37.1" %}
 
 package:
-  name: m2crypto
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: e4e42f068b78ccbf113e5d0a72ae5f480f6c3ace4940b91e4fff5598cfff6fb3
   patches:
     # remove parameterized from install_requires, it's only used in the tests
@@ -18,14 +19,13 @@ requirements:
   build:
     - {{ compiler("c") }}
   host:
+    - openssl
     - python
-    - swig >=2.0.4
     - setuptools
-    - openssl
+    - swig >=2.0.4
   run:
-    - python
-    - typing  # [py<35]
     - openssl
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,12 @@ source:
   patches:
     # remove parameterized from install_requires, it's only used in the tests
     - no-parameterized.patch
+    # set default_openssl path to conda prefix
+    - openssl_default.patch
 
 build:
   number: 1
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,13 @@ test:
     - M2Crypto.SSL
   commands:
     - pip check
+    - 'python -m pytest tests/ -v -rs -k "not test_ssl"'
   requires:
+    - parameterized
     - pip
+    - pytest
+  source_files:
+    - tests
 
 about:
   home: https://gitlab.com/m2crypto/m2crypto

--- a/recipe/no-parameterized.patch
+++ b/recipe/no-parameterized.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 38b5117..98b91c5 100644
+--- a/setup.py
++++ b/setup.py
+@@ -33,7 +33,7 @@ logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
+                     stream=sys.stdout, level=logging.INFO)
+ log = logging.getLogger('setup')
+ 
+-requires_list = ['parameterized']
++requires_list = []
+ if (2, 6) < sys.version_info[:2] < (3, 5):
+     requires_list = ['typing']
+ if sys.version_info[0] > 2:

--- a/recipe/openssl_default.patch
+++ b/recipe/openssl_default.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index 38b5117..c741399 100644
+--- a/setup.py
++++ b/setup.py
+@@ -128,7 +128,10 @@ class _M2CryptoBuildExt(build_ext.build_ext):
+         # type: (None) -> None
+         """Append custom openssl include file and library linking options."""
+         build_ext.build_ext.finalize_options(self)
+-        self.openssl_default = None
++        if sys.platform == 'win32':
++            self.openssl_default = os.getenv('LIBRARY_PREFIX')
++        else:
++            self.openssl_default = os.getenv('PREFIX')
+         self.set_undefined_options('build', ('openssl', 'openssl'))
+         if self.openssl is None:
+             self.openssl = self.openssl_default


### PR DESCRIPTION
This PR started as an effort to have `pip check` not fail for downstream projects as follows:

- add `pip check` to this feedstock's tests
- patch out the unnecessary `install_requires` entry for `parameterized` which is only used in the test suite [[ref](https://gitlab.com/search?group_id=307248&nav_source=navbar&project_id=346279&repository_ref=0.37.1&scope=&search=parameterized&search_code=true&snippets=false&utf8=%E2%9C%93)]

but I got carried away and also included some extra changes that I thought improved the recipe

- minor pedantic reformatting (to better match the template you get from grayskull
- use a patch to set the `default_openssl` path, rather than separate build scripts
- run the test suite using `pytest` - I had to exclude the `test_ssl` suite because of network communication issues I experienced

I hope these changes are kosher, I'm happy to pare it back to just the necessary ones if required.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
